### PR TITLE
fix(text-field): prevent error message from overflowing

### DIFF
--- a/src/components/Home/TextField.vue
+++ b/src/components/Home/TextField.vue
@@ -73,18 +73,29 @@ const { inputProps, labelProps, errorMessage, errorMessageProps } =
   .error {
     position: absolute;
     left: 0;
+    top: 100%;
+    margin-top: 0.25rem;
     display: none;
-    font-size: 0.875rem;
+    font-size: 0.75rem;
+    line-height: 1.2;
     color: rgb(239, 68, 68);
-    white-space: nowrap;
-    text-overflow: ellipsis;
     width: 100%;
+    word-wrap: break-word;
+    word-break: break-word;
+    hyphens: auto;
+    max-height: 3rem;
+    overflow-y: auto;
+    padding: 0.25rem 0;
+    scrollbar-width: thin;
+    scrollbar-color: rgb(239, 68, 68) transparent;
+    overflow-y: overlay;
   }
 
   &:has(:user-invalid) {
     .error {
       display: block;
     }
+    margin-bottom: calc(1em * 1.5 + 3rem);
   }
 }
 </style>


### PR DESCRIPTION
Before:
![Screenshot 2025-05-29 192829](https://github.com/user-attachments/assets/8a10506b-65dc-48af-8375-8c70692cc32f)

After:
![Screenshot 2025-05-29 195825](https://github.com/user-attachments/assets/926a94ab-a2c9-4660-ad28-94c89ed25388)
